### PR TITLE
Install libyang to azure pipeline

### DIFF
--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -53,33 +53,26 @@ jobs:
     displayName: "Download sonic swss common deb packages"
 
   - task: DownloadPipelineArtifact@2
-    # amd64 artifact name does not has arch suffix
-    condition: eq('${{ parameters.arch }}', 'amd64')
     inputs:
       source: specific
       project: build
       pipeline: Azure.sonic-buildimage.common_libs
       runVersion: 'latestFromBranch'
       runBranch: 'refs/heads/master'
-      artifact: common-lib
-      patterns: |
-        target/debs/buster/libyang-*.deb
-        target/debs/buster/libyang_*.deb
-    displayName: "Download libyang from amd64 common lib"
-
-  - task: DownloadPipelineArtifact@2
-    condition: ne('${{ parameters.arch }}', 'amd64')
-    inputs:
-      source: specific
-      project: build
-      pipeline: Azure.sonic-buildimage.common_libs
-      runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/master'
-      artifact: common-lib.${{ parameters.arch }}
+      path: $(Build.ArtifactStagingDirectory)/download
+      ${{ if eq(parameters.arch, 'amd64') }}:
+        artifact: common-lib
+      ${{ else }}:
+        artifact: common-lib.${{ parameters.arch }}
       patterns: |
         target/debs/buster/libyang-*.deb
         target/debs/buster/libyang_*.deb
     displayName: "Download libyang from common lib"
+  - script: |
+      set -ex
+      sudo dpkg -i $(find ./download -name *.deb)
+    workingDirectory: $(Build.ArtifactStagingDirectory)
+    displayName: "Install libyang from common lib"
 
   - script: |
       set -ex
@@ -95,10 +88,6 @@ jobs:
           libnl-genl-3-dev \
           libnl-route-3-dev \
           libnl-nf-3-dev
-
-      #install libyang
-      sudo dpkg -i ../libyang_1.0.73_${{ parameters.arch }}.deb
-      sudo dpkg -i ../libyang-dev_1.0.73_${{ parameters.arch }}.deb
 
       #install libswsscommon
       sudo dpkg -i ../libswsscommon_1.0.0_${{ parameters.arch }}.deb

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -52,6 +52,35 @@ jobs:
       runBranch: 'refs/heads/master'
     displayName: "Download sonic swss common deb packages"
 
+  - task: DownloadPipelineArtifact@2
+    # amd64 artifact name does not has arch suffix
+    condition: eq('${{ parameters.arch }}', 'amd64')
+    inputs:
+      source: specific
+      project: build
+      pipeline: Azure.sonic-buildimage.common_libs
+      runVersion: 'latestFromBranch'
+      runBranch: 'refs/heads/master'
+      artifact: common-lib
+      patterns: |
+        target/debs/${{ parameters.debian_version }}/libyang-*.deb
+        target/debs/${{ parameters.debian_version }}/libyang_*.deb
+    displayName: "Download libyang from amd64 common lib"
+
+  - task: DownloadPipelineArtifact@2
+    condition: ne('${{ parameters.arch }}', 'amd64')
+    inputs:
+      source: specific
+      project: build
+      pipeline: Azure.sonic-buildimage.common_libs
+      runVersion: 'latestFromBranch'
+      runBranch: 'refs/heads/master'
+      artifact: common-lib.${{ parameters.arch }}
+      patterns: |
+        target/debs/${{ parameters.debian_version }}/libyang-*.deb
+        target/debs/${{ parameters.debian_version }}/libyang_*.deb
+    displayName: "Download libyang from common lib"
+
   - script: |
       set -ex
       pwd
@@ -66,6 +95,10 @@ jobs:
           libnl-genl-3-dev \
           libnl-route-3-dev \
           libnl-nf-3-dev
+
+      #install libyang
+      sudo dpkg -i ../libyang_1.0.73_${{ parameters.arch }}.deb
+      sudo dpkg -i ../libyang-dev_1.0.73_${{ parameters.arch }}.deb
 
       #install libswsscommon
       sudo dpkg -i ../libswsscommon_1.0.0_${{ parameters.arch }}.deb

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -63,8 +63,8 @@ jobs:
       runBranch: 'refs/heads/master'
       artifact: common-lib
       patterns: |
-        target/debs/${{ parameters.debian_version }}/libyang-*.deb
-        target/debs/${{ parameters.debian_version }}/libyang_*.deb
+        target/debs/buster/libyang-*.deb
+        target/debs/buster/libyang_*.deb
     displayName: "Download libyang from amd64 common lib"
 
   - task: DownloadPipelineArtifact@2
@@ -77,8 +77,8 @@ jobs:
       runBranch: 'refs/heads/master'
       artifact: common-lib.${{ parameters.arch }}
       patterns: |
-        target/debs/${{ parameters.debian_version }}/libyang-*.deb
-        target/debs/${{ parameters.debian_version }}/libyang_*.deb
+        target/debs/buster/libyang-*.deb
+        target/debs/buster/libyang_*.deb
     displayName: "Download libyang from common lib"
 
   - script: |


### PR DESCRIPTION
#### Why I did it
sonic-swss-common lib will add dependency to libyang soon, so need install libyang lib to prevent build and UT break.

#### How I did it
Modify azure pipeline to install libyang in azure pipeline steps.

#### How to verify it
Pass all UT.

#### Which release branch to backport (provide reason below if selected)

#### Description for the changelog
Modify azure pipeline to install libyang in azure pipeline steps.

#### Link to config_db schema for YANG module changes

#### A picture of a cute animal (not mandatory but encouraged)

