### PR TITLE
[mstp] Fix for incorrectly passing mst internal index to stpsync

### DIFF
--- a/mstp/mstp_util.c
+++ b/mstp/mstp_util.c
@@ -1090,14 +1090,14 @@ bool mstputil_set_port_state(MSTP_INDEX mstp_index, PORT_ID port_number, enum L2
 
 	if(ifname)
 	{
-        stpsync_update_port_state(ifname, mstp_index, state);
+        stpsync_update_port_state(ifname, mst_id, state);
     }		
 	return true;
 }
 
 /*****************************************************************************/
-/* mstputil_flush: sets the port state for all the vlans associated          */
-/* with the input mst instance to the input state                            */
+/* mstputil_flush: Flushes the FDB for a given port of a specific MST        */
+/* insance if the fdb flush is pending after topology change                 */
 /*****************************************************************************/
 bool mstputil_flush(MSTP_INDEX mstp_index, PORT_ID port_number)
 {
@@ -1110,7 +1110,7 @@ bool mstputil_flush(MSTP_INDEX mstp_index, PORT_ID port_number)
     ifname = stp_intf_get_port_name(port_number);
     if(!ifname)
         return false;
-    stpsync_flush_instance_port(ifname, mstp_index);
+    stpsync_flush_instance_port(ifname, mst_id);
     STP_LOG_INFO("[MST %d] %s flush", mst_id, ifname);
   
 


### PR DESCRIPTION
**What was added**
Changes to fix wrongly passing mst internal index to stpsync api-s, which expect instance id. For MSTP, since the internal index and MST instance ids are not one-to-one mapped (for example, for CIST, the MST instance id 0 but the internal index 64). With these changes, the index are converted to MST instance id and passed to stpsync api-s

**Verified**
- Tested with with two instances (Default CIST and MST instance 1) in a triangle setup where all the three nodes were connected by 2 parallel links. The CIST had index 64 and MST 1 had index 0. The id 0 (for CIST) and 1 (MST 1) were correctly passed to stpsync and the ASIC records were created correct with corect instances. Configured 2 vlans. One VLAN was mapped to MST 1 and unmapped VLAN in CIST.
- No forwarding loops and high rate MAC move were observed (i.e., the STP records and port states for the correct insance were programmed correctly)