### PR TITLE
[mstp] Fix for port enable handling and rx pkt type check

### DIFF
--- a/mstp/mstp_mgr.c
+++ b/mstp/mstp_mgr.c
@@ -1983,6 +1983,7 @@ void mstpmgr_port_event(PORT_ID port_number, bool up)
                 if(ifname)
                     stpsync_update_bpdu_guard_shutdown(ifname, false);
             }
+            mstpmgr_enable_port(port_number);
         }
         else
         {

--- a/stp/stp_pkt.c
+++ b/stp/stp_pkt.c
@@ -377,7 +377,7 @@ void stp_pkt_rx_handler (evutil_socket_t fd, short what, void *arg)
     {
         if (stpmgr_protect_process(intf_node->port_id, vlan_id))
             return;
-        if (pkt[1] == 128)
+        if ((unsigned char)pkt[1] == 128)
         {
              mstpmgr_rx_bpdu(vlan_id, intf_node->port_id, &pkt[0], packet_len);
         }


### PR DESCRIPTION
**What was changed?**

Changes to fix the following:
-  Fixed the problem of not invoking mstp manager port enable api when an interface comes up from down state. This was missing and fixed by calling mstpmgr_enale_port() when port event api is called with "up" event.
- Fix for packet type comparison where unsigned char value 128 packet buffer is interpreted as -1 in some platforms

**Verified**
- In a three node tirangle setup, configured two MST instances: MST 1 and CIST, two vlans. One vlan was mapped to MST 1. The three nodes were connected by two parallel links
- After the MST port states stabilized, a forwarding link was disabled using command "sudo config interface shutdown" and noted that the topology changed correctly for both instances.
- When the interface was enabled back using command "sudo config interface startup", the topology change occured correctly.
- Tested in AMD and ARM platforms to ensure that MSTP BPDU was passed to MSTP protocol without dropping.