### PR TITLE
[stpctl] stpctl enhancements for mstp debugging commands

### DIFF
--- a/include/stp_debug.h
+++ b/include/stp_debug.h
@@ -8,7 +8,9 @@
 
 extern FILE *dbgfp;
 
+#define STP_DUMP_START      dbgfp = fopen("/var/log/stp_dmp.log", "w+")
 #define STP_DUMP(fmt, ...)  do {fprintf(dbgfp, fmt, ##__VA_ARGS__); fflush(dbgfp);}while(0)
+#define STP_DUMP_STOP       fclose(dbgfp)
 
 #define L2_STATE_STRING(s, p)       l2_port_state_to_string(s, p)
 

--- a/mstp/mstp_debug.c
+++ b/mstp/mstp_debug.c
@@ -492,7 +492,7 @@ void mstpdm_mstp_bridge()
 	MSTP_MSTID mstid;
 	MSTP_INDEX mstp_index;
 	MSTP_BRIDGE *mstp_bridge = mstpdata_get_bridge();
-    UINT8 buffer[100], buffer2[100], buffer3[100], buffer4[100], buffer5[100];
+    UINT8 buffer[500];
 
     MSTP_GLOBAL *mstp_global = &g_mstp_global;
     VLAN_ID vlan_id;
@@ -1043,6 +1043,7 @@ void mstpdbg_process_ctl_msg(void *msg)
 
     STP_LOG_INFO("cmd: %d", pmsg->cmd_type);
 
+    STP_DUMP_START;
     switch(pmsg->cmd_type)
     {
         case STP_CTL_DUMP_GLOBAL:
@@ -1232,6 +1233,12 @@ void mstpdbg_process_ctl_msg(void *msg)
             break;
         }
 
+        case STP_CTL_DUMP_LIBEV_STATS:
+        {
+            stpdbg_dump_stp_stats();
+            break;
+        }
+
         case STP_CTL_CLEAR_ALL:
         {
             mstpmgr_clear_statistics_all();
@@ -1250,4 +1257,5 @@ void mstpdbg_process_ctl_msg(void *msg)
             break;
         }
     }
+    STP_DUMP_STOP;
 }

--- a/mstp/mstp_util.c
+++ b/mstp/mstp_util.c
@@ -1096,8 +1096,8 @@ bool mstputil_set_port_state(MSTP_INDEX mstp_index, PORT_ID port_number, enum L2
 }
 
 /*****************************************************************************/
-/* mstputil_flush: sets the port state for all the vlans associated          */
-/* with the input mst instance to the input state                            */
+/* mstputil_flush: Flushes the FDB for a given port of a specific MST        */
+/* insance if the fdb flush is pending after topology change                 */
 /*****************************************************************************/
 bool mstputil_flush(MSTP_INDEX mstp_index, PORT_ID port_number)
 {

--- a/stp/stp_util.c
+++ b/stp/stp_util.c
@@ -1389,7 +1389,7 @@ int mask_to_string(BITMAP_T *bmp, uint8_t *str, uint32_t maxlen)
         return -1;
     }
 
-    int32_t bmp_id = 0;
+    int32_t bmp_id = BMP_INVALID_ID;
     uint32_t len = 0;
     do {
         if (len >= maxlen)

--- a/stpctl/stpctl.c
+++ b/stpctl/stpctl.c
@@ -32,6 +32,8 @@ CMD_LIST g_cmd_list[] = {
     "clrstsvlan",     STP_CTL_CLEAR_VLAN,
     "clrstsintf",     STP_CTL_CLEAR_INTF,
     "clrstsvlanintf", STP_CTL_CLEAR_VLAN_INTF,
+    "mst",      STP_CTL_DUMP_MST,
+    "mstport",  STP_CTL_DUMP_MST_PORT,
 };
 
 void print_cmds()
@@ -381,6 +383,29 @@ int send_command(int argc, char **argv)
             }
 
             msg.vlan_id = atoi(argv[2]);
+            strncpy(msg.intf_name, argv[3], IFNAMSIZ);
+            break;
+        }
+
+        case STP_CTL_DUMP_MST: 
+        {
+            if (!(argc == 3))
+            {
+                stpout("invalid number of args\n");
+                return -1;
+            }
+            msg.mst_id = atoi(argv[2]);
+            break;
+        }
+
+        case STP_CTL_DUMP_MST_PORT: 
+        {
+            if (!(argc == 4))
+            {
+                stpout("invalid number of args\n");
+                return -1;
+            }
+            msg.mst_id = atoi(argv[2]);
             strncpy(msg.intf_name, argv[3], IFNAMSIZ);
             break;
         }


### PR DESCRIPTION
**What added/changed?**

stpctl enhancements and bug fixes for stpctl MSTP commands
- Fixed stpctl for the problem of MSTP debugging did not work since it did not have code for opening and closing stp_dmp.log file (DUMP_START and DUMP_STOP).
- stpctl (stp debugging) is enhanced for dummping MSTP info for specific MST instance, MST port and STP statistics.
- Increased buffer size for constructing information string for MSTP debugging apis so that more number of interfaces and vlans can be displayed completely
- Fix for mask_to_string() to avoid missing port 0 in the port masks.
- Incorrect comments in the function header were corrected for mstputil_flush() function.

**Verified**
- Inside the stp docker, the following commands were executed.
- **"stpctl help"** shows commands "stpctl mst" and "stpctl mstport"
- **"stpctl mst \<instance id\>"** shows the information starting from **MSTI CLASS (MST ID \<instance id\>),** with correct port masks including port 0, and vlan mask.
- **"stpctl mstport \<instance id\> \<ifname\>"** shows the MST interface information starting from **MSTI PORT CLASS \<ifname\> (\<ifid\>)**
- **"stpctl lstats"** shows expected statistics such as BPDU rx/tx count, max STP ports and event_count.
- **"stpctl all"** shows all debugging information including information for MSTP. The "admin_pt2pt_mask" shows more than 125 ports.