### PR TITLE
fix: sync port_fast to APPL_DB on boot when portfast already configured

### DIFF
--- a/stp/stp_mgr.c
+++ b/stp/stp_mgr.c
@@ -1153,16 +1153,20 @@ static bool stpmgr_config_fastspan(PORT_ID port_id, bool enable)
 
 	if (enable)
 	{
-		if(is_member(g_fastspan_config_mask, port_id))
+		if(is_member(g_fastspan_config_mask, port_id)){
+            stpsync_update_port_fast(stp_intf_get_port_name(port_id), true);
 		    return ret;
+        }
         set_mask_bit(g_fastspan_config_mask, port_id);
         set_mask_bit(g_fastspan_mask, port_id);
         stpsync_update_port_fast(stp_intf_get_port_name(port_id), true);
 	}
 	else
 	{
-		if(!is_member(g_fastspan_config_mask, port_id))
+		if(!is_member(g_fastspan_config_mask, port_id)){
+            stpsync_update_port_fast(stp_intf_get_port_name(port_id), false);
 		    return ret;
+        }
         clear_mask_bit(g_fastspan_config_mask, port_id);
         clear_mask_bit(g_fastspan_mask, port_id);
         stpsync_update_port_fast(stp_intf_get_port_name(port_id), false);


### PR DESCRIPTION
## Description
After a reboot, `stpd` initializes `g_fastspan_config_mask` to all-1s
(`PORT_MASK_SET_ALL`) as a boot-time default. When `stpmgrd` replays
persisted CONFIG_DB with `portfast=true`, `stpmgr_config_fastspan()`
hits the `is_member` guard and returns early without calling
`stpsync_update_port_fast()`. As a result, `port_fast` is never written
to APPL_DB and `show spanning-tree` displays PortFast as **N** even
though it is configured.

This only affects reboots: on first-time setup the CLI creates STP_PORT
entries with `portfast=false`, which triggers the disable path and clears
the mask bits before the user enables PortFast. After reboot the config
is already `true` so no disable/clear step occurs, leaving the guard
always firing on the enable path.

## Fix
Ensure `stpsync_update_port_fast()` is called **before** the early
return in both the enable and disable branches of
`stpmgr_config_fastspan()`. This guarantees APPL_DB reflects the current
portfast state whenever config is replayed, regardless of the initial
mask value.

## Testing
- Configure portfast on an interface, reboot.
- Verify `show spanning-tree` shows PortFast **Y** after boot.
- Verify toggling portfast on/off still works correctly at runtime.