### PR TITLE
azure-pipelines: migrate libyang1 deb install to libyang3

### DIFF
--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -66,7 +66,7 @@ jobs:
       runVersion: 'latestFromBranch'
       runBranch: 'refs/heads/master'
       patterns: |
-        target/debs/bookworm/libyang*.deb
+        target/debs/bookworm/libyang3_*.deb
         target/debs/bookworm/libnl*.deb
     displayName: "Download bookworm debs"
 
@@ -79,7 +79,7 @@ jobs:
       sudo apt-get install -y libhiredis0.14 libhiredis-dev
 
       # LIBYANG
-      sudo dpkg -i ../target/debs/bookworm/libyang*1.0.73*.deb
+      sudo dpkg -i ../target/debs/bookworm/libyang3_*.deb
 
       # Install libnl3
       sudo apt-get -y purge libnl-3-dev libnl-route-3-dev || true


### PR DESCRIPTION
#### Why I did it
sonic-buildimage no longer builds the libyang1 packages (`libyang_1.0.73`, `libyang-cpp`, `python3-yang`); it now builds only libyang3. The sonic-stp CI installs the removed `libyang*1.0.73*.deb` from the sonic-buildimage common-lib build assets, which will fail once those debs no longer exist.

Part of sonic-net/sonic-buildimage#22385.

#### How I did it
Updated `.azure-pipelines/build-template.yml` to install the libyang3 deb using a versionless glob instead of the removed libyang 1.0.73 deb:
- Install: `../target/debs/bookworm/libyang*1.0.73*.deb` -> `../target/debs/bookworm/libyang3_*.deb`

The download filter `target/debs/bookworm/libyang*.deb` already matches the libyang3 deb, so it was left unchanged. No `libyang-cpp` or `python3-yang` references exist in this repo.

#### How to verify it
Run the Azure pipeline build for sonic-stp and confirm the "Download bookworm debs" step fetches the libyang3 deb and the libyang install step (`sudo dpkg -i ../target/debs/bookworm/libyang3_*.deb`) succeeds.

#### Description for the changelog
azure-pipelines: migrate libyang1 deb install to libyang3
