### PR TITLE
fix strncpy truncation; enable hardening=+all and FORTIFY_SOURCE=3

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -8,7 +8,9 @@ DPKG_EXPORT_BUILDFLAGS = 1
 include /usr/share/dpkg/default.mk
 
 # see FEATURE AREAS in dpkg-buildflags(1)
-#export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+# Upgrade FORTIFY_SOURCE to level 3 (dpkg default is =2).
+export DEB_CPPFLAGS_MAINT_APPEND = -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3
 
 # see ENVIRONMENT in dpkg-buildflags(1)
 # package maintainers to append CFLAGS

--- a/stp/stp_intf.c
+++ b/stp/stp_intf.c
@@ -227,7 +227,8 @@ bool stp_intf_ioctl_get_ifname(uint32_t kif_index, char * if_name)
     if(ioctl(g_stpd_ioctl_sock, SIOCGIFNAME, &ifr) < 0)
         return false;
 
-    strncpy(if_name, ifr.ifr_name, IFNAMSIZ);
+    strncpy(if_name, ifr.ifr_name, IFNAMSIZ - 1);
+    if_name[IFNAMSIZ - 1] = '\0';
     return true;
 }
 
@@ -266,7 +267,8 @@ INTERFACE_NODE * stp_intf_create_intf_node(char * ifname, uint32_t kif_index)
     /* Update interface name */
     if(ifname)
     {
-        strncpy(node->ifname, ifname, IFNAMSIZ);
+        strncpy(node->ifname, ifname, IFNAMSIZ - 1);
+        node->ifname[IFNAMSIZ - 1] = '\0';
     }
     else
     {

--- a/stp/stp_netlink.c
+++ b/stp/stp_netlink.c
@@ -293,7 +293,8 @@ static int stp_netlink_recv(int nl_fd, bool read_all)
                 if (rt_list[IFLA_IFNAME])
                 {
                     ptr = rt_list[IFLA_IFNAME];
-                    strncpy(if_db.ifname, (char *)RTA_DATA(ptr), IFNAMSIZ);
+                    strncpy(if_db.ifname, (char *)RTA_DATA(ptr), IFNAMSIZ - 1);
+                    if_db.ifname[IFNAMSIZ - 1] = '\0';
 
                     if(!stp_netlink_intf_is_valid(if_db.ifname))
                     {

--- a/stpctl/stpctl.c
+++ b/stpctl/stpctl.c
@@ -163,7 +163,8 @@ int send_command(int argc, char **argv)
                 return -1;
             }
             msg.vlan_id = atoi(argv[2]);
-            strncpy(msg.intf_name, argv[3], IFNAMSIZ);
+            strncpy(msg.intf_name, argv[3], IFNAMSIZ - 1);
+            msg.intf_name[IFNAMSIZ - 1] = '\0';
             break;
         }
 
@@ -198,7 +199,8 @@ int send_command(int argc, char **argv)
                 return -1;
             }
 
-            strncpy(msg.intf_name, argv[2], IFNAMSIZ);
+            strncpy(msg.intf_name, argv[2], IFNAMSIZ - 1);
+            msg.intf_name[IFNAMSIZ - 1] = '\0';
             break;
         }
 
@@ -296,8 +298,10 @@ int send_command(int argc, char **argv)
                 msg.dbg.flags |= STPCTL_DBG_SET_PORT;
                 if (0 == strncmp("all", argv[3], 3))
                     msg.intf_name[0] = '\0';
-                else
-                    strncpy(msg.intf_name, argv[3], IFNAMSIZ);
+                else {
+                    strncpy(msg.intf_name, argv[3], IFNAMSIZ - 1);
+                    msg.intf_name[IFNAMSIZ - 1] = '\0';
+                }
                 if (0 == strncmp("on", argv[4], 2))
                     msg.dbg.port = 1;
                 else if (0 == strncmp("off", argv[4], 3))
@@ -370,7 +374,8 @@ int send_command(int argc, char **argv)
                 return -1;
             }
 
-            strncpy(msg.intf_name, argv[2], IFNAMSIZ);
+            strncpy(msg.intf_name, argv[2], IFNAMSIZ - 1);
+            msg.intf_name[IFNAMSIZ - 1] = '\0';
             break;
         }
 
@@ -383,7 +388,8 @@ int send_command(int argc, char **argv)
             }
 
             msg.vlan_id = atoi(argv[2]);
-            strncpy(msg.intf_name, argv[3], IFNAMSIZ);
+            strncpy(msg.intf_name, argv[3], IFNAMSIZ - 1);
+            msg.intf_name[IFNAMSIZ - 1] = '\0';
             break;
         }
 
@@ -406,7 +412,8 @@ int send_command(int argc, char **argv)
                 return -1;
             }
             msg.mst_id = atoi(argv[2]);
-            strncpy(msg.intf_name, argv[3], IFNAMSIZ);
+            strncpy(msg.intf_name, argv[3], IFNAMSIZ - 1);
+            msg.intf_name[IFNAMSIZ - 1] = '\0';
             break;
         }
 


### PR DESCRIPTION
## Why I did it

`strncpy(dest, src, IFNAMSIZ)` fills all IFNAMSIZ bytes without leaving room for a null terminator when src is IFNAMSIZ-1 chars or longer. Replace all such instances with `strncpy(dest, src, IFNAMSIZ - 1)` followed by an explicit null termination.

Also uncomment `DEB_BUILD_MAINT_OPTIONS = hardening=+all` and upgrade FORTIFY_SOURCE to level 3 so the stronger compile-time check catches similar issues in future.

## How I did it

- `stp/stp_netlink.c`: fix `if_db.ifname` copy from netlink `RTA_DATA`
- `stp/stp_intf.c`: fix `ifr_name` copy from `ioctl(SIOCGIFNAME)`, and `node->ifname` copy
- `stpctl/stpctl.c`: fix `intf_name` copies from `argv` (6 sites)
- `debian/rules`: uncomment `hardening=+all`, add `FORTIFY_SOURCE=3`

## How to verify it

Build the package. All previously-flagged strncpy sites compile cleanly under `-D_FORTIFY_SOURCE=3`.